### PR TITLE
show error message when printer is not reachable

### DIFF
--- a/addons/pos_restaurant/static/src/js/multiprint.js
+++ b/addons/pos_restaurant/static/src/js/multiprint.js
@@ -31,6 +31,10 @@ var Printer = core.Class.extend(mixins.PropertiesMixin,{
                         send_printing_job();
                     },function(){
                         self.receipt_queue.unshift(r);
+                        posmodel.gui.show_popup('error',{
+                           'title': 'Printer not accessible',
+                            'body':  'Printer "' + self.config.name + '" cannot be reached!',
+                        });
                     });
             }
         }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
show error message when printer is not reachable

Current behavior before PR:
no message if printer is not available

Desired behavior after PR is merged:
show error message when printer is not reachable


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
